### PR TITLE
Updated gifted-chat to fix React Native 0.60 error for missing ListView

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "homepage": "https://github.com/livechat/react-native-livechat#readme",
   "dependencies": {
     "react-native-animatable": "^1.2.4",
-    "react-native-gifted-chat": "^0.3.0"
+    "react-native-gifted-chat": "^0.9.11"
   }
 }


### PR DESCRIPTION
Running `react-native-livechat` on React Native 0.60 results in an error because the `ListView` has been removed.

This change updates the gifted-chat dependency to fix that:

| Before | After |
| --- | --- |
| ![Screen Shot 2019-09-10 at 12 15 16 PM](https://user-images.githubusercontent.com/2937410/64643700-d2ca4480-d3c5-11e9-844e-18cd34e3d75f.png) | ![Screen Shot 2019-09-10 at 12 23 04 PM](https://user-images.githubusercontent.com/2937410/64643713-da89e900-d3c5-11e9-9a09-506b9dd593e5.png) |
