### PR TITLE
Replace WebView URL with one that supports JS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To do it, use `react-native-webview` library and add `Webview` component with yo
 ```javascript
 <WebView
   source={{
-    uri: 'https://secure.livechatinc.com/licence/<LICENSE_ID>/v2/open_chat.cgi',
+    uri: 'https://direct.lc.chat/<LICENSE_ID/',
   }}
 />
 ```


### PR DESCRIPTION
As the title says, the WebView URI used doesn't work with the JavaScript API mentioned in the LiveChat docs. Specifically, it doesn't expose access to LC_API, the global object with LiveChat's functions. Using the new link enables that access, so apps can inject JS to update user's name, email, and other variables, without filling in a redundant form.

Also I think it might come with performance improvements on older devices? Not 100% on that one but it feels faster in testing on my old Android.