### PR TITLE
Fix config parameter groupId instead of group

### DIFF
--- a/LiveChat/index.js
+++ b/LiveChat/index.js
@@ -293,7 +293,7 @@ export default class LiveChat extends Component {
 			redirectUri,
 		}
 		if (this.props.group !== null) {
-			config.group = this.props.group
+			config.groupId = this.props.group
 		}
 		const customerSDK = CustomerSdkInit(config)
 		this.customerSDK = customerSDK


### PR DESCRIPTION
Following the docs of [Customer SDK](https://developers.livechat.com/docs/extending-chat-widget/customer-sdk/) the config optional id of the group you wish to connect for is groupId not group.

